### PR TITLE
fix: standardize hover tooltips across all modules

### DIFF
--- a/frontend/src/homepage/pages/Homepage.jsx
+++ b/frontend/src/homepage/pages/Homepage.jsx
@@ -79,7 +79,7 @@ const Homepage = () => {
                  Supported by:
                </span>
               </div>
-              <div className="flex items-center gap-6">
+              <div className="flex flex-wrap items-center gap-6">
                 <img src={moeLogo} alt="MOE Logo" className="h-[4.2rem] pointer-events-auto dark:invert" />
                 <img src={mosLogo} alt="MOS Logo" className="h-[4.2rem] pointer-events-auto dark:invert" /> 
                 <img src={constructSteelLogo} alt="Construct Steel Logo" className="h-[1.44rem] pointer-events-auto" />

--- a/frontend/src/modules/shared/components/EngineeringModule.jsx
+++ b/frontend/src/modules/shared/components/EngineeringModule.jsx
@@ -147,6 +147,8 @@ export const EngineeringModule = ({
 
   const [showResetButton, setShowResetButton] = useState(false);
   const [showInputDock, setShowInputDock] = useState(true);
+  const colorPickerRef = useRef(null);
+  const [customBgColor, setCustomBgColor] = useState("");
   const [showOutputDock, setShowOutputDock] = useState(false);
   const [showLogs, setShowLogs] = useState(false);
   const [isDesignComplete, setIsDesignComplete] = useState(false);
@@ -856,10 +858,9 @@ export const EngineeringModule = ({
     // Only keep truly generic part-name labels for parts
     // the backend never annotates (e.g. SeatedAngle, Member).
     const staticFallbacks = {
-      cleatAngle: "Cleat Angle",
-      SeatedAngle: "Seated Angle",
-      Member: "Member",
-      Angle: "Angle",
+      "Cleat Angle": "Cleat Angle",
+      "Seated Angle": "Seated Angle",
+      "Member": "Member",
     };
 
     const final = {

--- a/frontend/src/modules/shared/components/EngineeringModule.jsx
+++ b/frontend/src/modules/shared/components/EngineeringModule.jsx
@@ -1077,7 +1077,7 @@ export const EngineeringModule = ({
         }, [])}
       </div>
 
-      <div className="relative flex flex-row h-full w-full">
+      <div className="relative flex flex-row flex-1 overflow-hidden w-full">
         {/* Input Dock Toggle Button - Fixed to left, shows when dock is closed (Desktop only) */}
         {!showInputDock && !isMobile && (
           <button

--- a/frontend/src/modules/shared/components/EngineeringModule.jsx
+++ b/frontend/src/modules/shared/components/EngineeringModule.jsx
@@ -847,49 +847,32 @@ export const EngineeringModule = ({
     setScreenshotTrigger(true);
   };
 
-  // Default hover dictionary mapping per-part names to labels
-  // Prioritize ctxHoverDict values from backend over defaults
-  // Use useMemo to recalculate when ctxHoverDict changes
+  // Build the hover dictionary: backend values take priority.
+  // We intentionally do NOT include default fallback strings for parts like
+  // Beam/Column/Plate so that when the backend provides nothing, SmartPart
+  // falls back to just the part name (clean), rather than a static string.
   const hoverDict = useMemo(() => {
-    const defaults = {
-      // Defaults (fallback if backend doesn't provide)
-      Beam: "Beam",
-      Column: "Column",
-      Plate: "Plate",
-      Weld: "Weld",
-      Welds: "Welds",
-      Bolt: "Bolt",
-      Bolts: "Bolts",
+    // Backend hover_dict values are the source of truth.
+    // Only keep truly generic part-name labels for parts
+    // the backend never annotates (e.g. SeatedAngle, Member).
+    const staticFallbacks = {
       cleatAngle: "Cleat Angle",
       SeatedAngle: "Seated Angle",
-      Connector: "Connector",
-      EndPlate: "End Plate",
       Member: "Member",
       Angle: "Angle",
     };
 
-    // Backend hover_dict values override defaults
     const final = {
-      ...defaults,
+      ...staticFallbacks,
       ...(ctxHoverDict || {}),
     };
 
-    // Debug: log hoverDict to see what we have
     if (ctxHoverDict && Object.keys(ctxHoverDict).length > 0) {
-      console.log('[EngineeringModule] ctxHoverDict:', ctxHoverDict);
-      console.log('[EngineeringModule] Final hoverDict:', final);
+      console.log('[EngineeringModule] hoverDict from backend:', final);
     }
 
     return final;
   }, [ctxHoverDict]);
-
-  // If backend provided bolt details but no separate Bolt mesh exists,
-  // enrich the Plate hover to include bolt info as a fallback.
-  const hasBoltMesh = Boolean(cadModelPaths?.Bolt || cadModelPaths?.Bolts);
-  if (!hasBoltMesh && (ctxHoverDict && ctxHoverDict.Bolt)) {
-    const boltText = String(ctxHoverDict.Bolt).replace(/<br\s*\/?>/gi, ' ');
-    hoverDict.Plate = hoverDict.Plate ? `${hoverDict.Plate}: ${boltText}` : boltText;
-  }
 
   const handleHoverLabel = (label, clientX, clientY) => {
     if (!label) return;

--- a/frontend/src/modules/shared/components/cad/SceneManager.jsx
+++ b/frontend/src/modules/shared/components/cad/SceneManager.jsx
@@ -60,7 +60,9 @@ export const SceneManager = forwardRef(({
 
               const mesh = new THREE.Mesh(geometry);
               mesh.name = key;
-              mesh.userData.hoverLabel = hoverDict?.[key] || key;
+              // Don't pre-bake hoverLabel at load time: hoverDict may be empty.
+              // SmartPart will look up the label from hoverDict at render time.
+              mesh.userData.hoverLabel = null;
 
               parsedData[key] = mesh;
               disposables.push(geometry);
@@ -221,7 +223,7 @@ export const SceneManager = forwardRef(({
                 rotation={finalRotation}
                 scale={modelScale}
                 hoverDict={hoverDict}
-                hoverLabel={m.hoverLabel}
+                hoverLabel={null}
                 isHovered={hoveredMeshId === meshId}
                 onHover={handlePartHover}
                 onHoverEnd={handlePartHoverEnd}

--- a/frontend/src/modules/shared/components/cad/SceneManager.jsx
+++ b/frontend/src/modules/shared/components/cad/SceneManager.jsx
@@ -282,7 +282,7 @@ export const SceneManager = forwardRef(({
             rotation={finalRotation}
             scale={modelScale}
             hoverDict={hoverDict}
-            hoverLabel={hoverDict?.[name] || name}
+            hoverLabel={null}
             isHovered={hoveredMeshId === meshId}
             onHover={handlePartHover}
             onHoverEnd={handlePartHoverEnd}

--- a/frontend/src/modules/shared/components/cad/SmartPart.jsx
+++ b/frontend/src/modules/shared/components/cad/SmartPart.jsx
@@ -91,8 +91,10 @@ export const SmartPart = ({
       }
 
       // Try semantic alias (e.g., "Connector" -> look up hoverDict["Plate"])
-      if (!label && PART_ALIASES[lower]) {
-        const aliasKey = PART_ALIASES[lower];
+      // Also try with spaces stripped so "Cleat Angle" matches alias key "cleatangle"
+      const lowerNoSpace = lower.replace(/\s+/g, '');
+      const aliasKey = PART_ALIASES[lower] || PART_ALIASES[lowerNoSpace];
+      if (!label && aliasKey) {
         label = hoverDict[aliasKey] || hoverDict[aliasKey.toLowerCase()];
       }
     }

--- a/frontend/src/modules/shared/components/cad/SmartPart.jsx
+++ b/frontend/src/modules/shared/components/cad/SmartPart.jsx
@@ -62,6 +62,8 @@ export const SmartPart = ({
       'end plate': 'Plate',
       'end-plate': 'Plate',
       'cleatangle': 'Angle',
+      'seatedangle': 'Angle',
+      'coverplate': 'Cover Plate',
     };
 
     // Try multiple key variations in hoverDict first

--- a/frontend/src/modules/shared/components/cad/SmartPart.jsx
+++ b/frontend/src/modules/shared/components/cad/SmartPart.jsx
@@ -46,12 +46,23 @@ export const SmartPart = ({
   useCursor(localHovered || isHovered);
 
   // 2. LABEL RESOLUTION
-  // Your original complex logic preserved exactly as requested
   const resolvedLabel = useMemo(() => {
     if (hoverLabel) return hoverLabel;
 
     const lower = name?.toLowerCase() || '';
     const capitalized = name?.charAt(0).toUpperCase() + name?.slice(1).toLowerCase();
+
+    // Semantic aliases: map 3D section/part names to hover_dict keys.
+    // The CAD backend uses section names like "Connector" or "EndPlate" for
+    // what the Python modules call "Plate" in hover_dict. This mapping bridges
+    // that naming gap so hover details always display correctly.
+    const PART_ALIASES = {
+      'connector': 'Plate',
+      'endplate': 'Plate',
+      'end plate': 'Plate',
+      'end-plate': 'Plate',
+      'cleatangle': 'Angle',
+    };
 
     // Try multiple key variations in hoverDict first
     let label = null;
@@ -60,14 +71,10 @@ export const SmartPart = ({
       label = hoverDict[name];
 
       // Try lowercase
-      if (!label) {
-        label = hoverDict[lower];
-      }
+      if (!label) label = hoverDict[lower];
 
       // Try capitalized (first letter uppercase, rest lowercase)
-      if (!label) {
-        label = hoverDict[capitalized];
-      }
+      if (!label) label = hoverDict[capitalized];
 
       // Try singular if plural (e.g., "Bolts" -> "Bolt")
       if (!label && lower.endsWith('s') && lower.length > 1) {
@@ -79,6 +86,12 @@ export const SmartPart = ({
       if (!label && !lower.endsWith('s')) {
         const plural = name + 's';
         label = hoverDict[plural] || hoverDict[plural.toLowerCase()];
+      }
+
+      // Try semantic alias (e.g., "Connector" -> look up hoverDict["Plate"])
+      if (!label && PART_ALIASES[lower]) {
+        const aliasKey = PART_ALIASES[lower];
+        label = hoverDict[aliasKey] || hoverDict[aliasKey.toLowerCase()];
       }
     }
 

--- a/frontend/src/modules/shared/components/cad/SmartPart.jsx
+++ b/frontend/src/modules/shared/components/cad/SmartPart.jsx
@@ -61,8 +61,10 @@ export const SmartPart = ({
       'endplate': 'Plate',
       'end plate': 'Plate',
       'end-plate': 'Plate',
-      'cleatangle': 'Angle',
-      'seatedangle': 'Angle',
+      'cleatangle': 'Cleat Angle',
+      'cleat angle': 'Cleat Angle',
+      'seatedangle': 'Seated Angle',
+      'seated angle': 'Seated Angle',
       'coverplate': 'Cover Plate',
     };
 

--- a/osdag_core/design_type/compression_member/compression_column.py
+++ b/osdag_core/design_type/compression_member/compression_column.py
@@ -585,7 +585,10 @@ class ColumnDesign(Member):
         out_list.append(t1)
 
         # Populate hover dict
-        self.hover_dict["Column"] = f"Column: {self.result_designation if flag else ''}"
+        self.hover_dict["Column"] = (
+            f"<b>Column</b><br>"
+            f"{self.result_designation if flag else ''}"
+        )
         
         return out_list
 

--- a/osdag_core/design_type/compression_member/compression_welded.py
+++ b/osdag_core/design_type/compression_member/compression_welded.py
@@ -768,11 +768,21 @@ class Compression_welded(Member):
         # Populate hover_dict for 3D model tooltips
         if flag and hasattr(self, 'hover_dict'):
              if hasattr(self, 'section_size_1'):
-                 self.hover_dict["Member"] = f"Member: {self.section_size_1.designation}"
+                 self.hover_dict["Member"] = (
+                     f"<b>Member</b><br>"
+                     f"{self.section_size_1.designation}"
+                 )
              if hasattr(self, 'plate'):
-                 self.hover_dict["Plate"] = f"Plate: {self.plate.length}x{self.plate.height}x{self.plate.thickness_provided}"
+                 self.hover_dict["Plate"] = (
+                     f"<b>Plate</b><br>"
+                     f"{self.plate.length}x{self.plate.height}x{self.plate.thickness_provided}"
+                 )
              if hasattr(self, 'weld'):
-                 self.hover_dict["Weld"] = f"Weld: {self.weld.size}mm size, {self.weld.length}mm length"
+                 self.hover_dict["Weld"] = (
+                     f"<b>Weld</b><br>"
+                     f"Size: {self.weld.size} mm<br>"
+                     f"Length: {self.weld.length} mm"
+                 )
         
         return out_list
 

--- a/osdag_core/design_type/connection/beam_beam_end_plate_splice.py
+++ b/osdag_core/design_type/connection/beam_beam_end_plate_splice.py
@@ -490,38 +490,40 @@ class BeamBeamEndPlateSplice(MomentConnection):
         out_list.append(t31)
         
         # Populate hover dict
+        try:
+            # Beam
+            self.hover_dict["Beam"] = f"<b>Beam</b>: {self.supported_section.designation if flag else ''}"
 
-        # Beam
-        self.hover_dict["Beam"] = f"<b>Beam</b>: {self.supported_section.designation if flag else ''}"
+            # End Plate
+            self.hover_dict["Plate"] = (
+                f"<b>End Plate</b>: {self.ep_width_provided if flag else ''} mm x "
+                f"{self.ep_height_provided if flag else ''} mm x "
+                f"{self.plate_thickness if flag else ''} mm"
+                f"<br><b>Bolt</b> Grade: {self.bolt_grade_provided if flag else ''}, "
+                f"Dia: {self.bolt_diameter_provided if flag else ''} mm, "
+                f"Nos: {self.bolt_numbers if flag else ''}"
+                f"<br><b>Weld</b> Size (Web): {self.weld_size_web if flag else ''} mm"
+            )
 
-        # End Plate
-        self.hover_dict["Plate"] = (
-            f"<b>End Plate</b>: {self.ep_width_provided if flag else ''} mm x "
-            f"{self.ep_height_provided if flag else ''} mm x "
-            f"{self.plate_thickness if flag else ''} mm"
-            f"<br><b>Bolt</b> Grade: {self.bolt_grade_provided if flag else ''}, "
-            f"Dia: {self.bolt_diameter_provided if flag else ''} mm, "
-            f"Nos: {self.bolt_numbers if flag else ''}"
-            f"<br><b>Weld</b> Size (Web): {self.weld_size_web if flag else ''} mm"
-        )
+            # Bolt
+            self.hover_dict["Bolt"] = (
+                f"<b>Bolt</b><br>"
+                f"Diameter: {self.bolt_diameter_provided if flag else ''} mm<br>"
+                f"Grade: {self.bolt_grade_provided if flag else ''}<br>"
+                f"No. of Bolts: {self.bolt_numbers if flag else ''}<br>"
+                f"Combined Capacity: {self.combined_capacity_critical_bolt if flag else ''}"
+            )
 
-        # Bolt
-        self.hover_dict["Bolt"] = (
-            f"<b>Bolt</b><br>"
-            f"Diameter: {self.bolt_diameter_provided if flag else ''} mm<br>"
-            f"Grade: {self.bolt_grade_provided if flag else ''}<br>"
-            f"No. of Bolts: {self.bolt_numbers if flag else ''}<br>"
-            f"Combined Capacity: {self.combined_capacity_critical_bolt if flag else ''}"
-        )
-
-        # Weld
-        self.hover_dict["Weld"] = (
-            f"<b>Weld</b><br>"
-            f"Type: Groove Weld<br>"
-            f"Web Weld Size: {self.weld_size_web if flag else ''} mm<br>"
-            f"Web Weld Length: {self.weld_length_web if flag else ''} mm<br>"
-            f"Allowable Stress: {self.allowable_stress if flag else ''}"
-        )
+            # Weld
+            self.hover_dict["Weld"] = (
+                f"<b>Weld</b><br>"
+                f"Type: Groove Weld<br>"
+                f"Web Weld Size: {self.weld_size_web if flag else ''} mm<br>"
+                f"Web Weld Length: {self.weld_length_web if flag else ''} mm<br>"
+                f"Allowable Stress: {self.allowable_stress if flag else ''}"
+            )
+        except Exception:
+            pass
 
         return out_list
 

--- a/osdag_core/design_type/connection/beam_beam_end_plate_splice.py
+++ b/osdag_core/design_type/connection/beam_beam_end_plate_splice.py
@@ -492,21 +492,17 @@ class BeamBeamEndPlateSplice(MomentConnection):
         # Populate hover dict
 
         # Beam
-        self.hover_dict["Beam"] = (
-            f"<b>Beam</b><br>"
-            f"Depth: {self.beam_D if flag else ''} mm<br>"
-            f"Flange Width: {self.beam_bf if flag else ''} mm<br>"
-            f"Web Thickness: {self.beam_tw if flag else ''} mm<br>"
-            f"Flange Thickness: {self.beam_tf if flag else ''} mm"
-        )
+        self.hover_dict["Beam"] = f"<b>Beam</b>: {self.supported_section.designation if flag else ''}"
 
         # End Plate
         self.hover_dict["Plate"] = (
-            f"<b>End Plate</b><br>"
-            f"Width: {self.ep_width_provided if flag else ''} mm<br>"
-            f"Height: {self.ep_height_provided if flag else ''} mm<br>"
-            f"Thickness: {self.plate_thickness if flag else ''} mm<br>"
-            f"Moment Capacity: {self.call_helper.plate_moment_capacity if flag else ''}"
+            f"<b>End Plate</b>: {self.ep_width_provided if flag else ''} mm x "
+            f"{self.ep_height_provided if flag else ''} mm x "
+            f"{self.plate_thickness if flag else ''} mm"
+            f"<br><b>Bolt</b> Grade: {self.bolt_grade_provided if flag else ''}, "
+            f"Dia: {self.bolt_diameter_provided if flag else ''} mm, "
+            f"Nos: {self.bolt_numbers if flag else ''}"
+            f"<br><b>Weld</b> Size (Web): {self.weld_size_web if flag else ''} mm"
         )
 
         # Bolt

--- a/osdag_core/design_type/connection/beam_column_end_plate.py
+++ b/osdag_core/design_type/connection/beam_column_end_plate.py
@@ -597,24 +597,32 @@ class BeamColumnEndPlate(MomentConnection):
         self.hover_dict["Column"] = f"<b>Column</b>: {self.supporting_section.designation if flag else ''}"
         self.hover_dict["Beam"] = f"<b>Beam</b>: {self.supported_section.designation if flag else ''}"
 
-        self.hover_dict["Plate"] = (
-            f"<b>Plate</b>: {float(self.ep_width_provided) if flag else ''} mm x "
-            f"{float(self.ep_height_provided) if flag else ''} mm x "
-            f"{self.plate_thickness if flag else ''} mm"
-            f"<br><b>Bolt</b> Grade: {self.bolt.bolt_grade_provided if flag else ''}, "
-            f"Dia: {int(self.bolt.bolt_diameter_provided) if flag else ''} mm, "
-            f"Nos: {int(self.bolt_numbers) if flag else ''}"
-            f"<br><b>Weld</b> Size (Web): {self.weld_size_web if flag else ''} mm"
-        )
-        
-        self.hover_dict["Bolt"] = (
-            f"<b>Bolt</b><br>Grade: {self.bolt.bolt_grade_provided if flag else ''}"
-            f"<br>Diameter: {int(self.bolt.bolt_diameter_provided) if flag else ''} mm"
-            f"<br>No. of Bolts: {int(self.bolt_numbers) if flag else ''}"
-        )
-        self.hover_dict["Weld"] = (
-            f"<b>Weld</b><br>Size (Web): {self.weld_size_web if flag else ''} mm"
-        )
+        try:
+            plate_width = self.ep_width_provided if flag else ''
+            plate_height = self.ep_height_provided if flag else ''
+            bolt_dia = self.bolt.bolt_diameter_provided if flag else ''
+            bolt_nos = self.bolt_numbers if flag else ''
+            
+            self.hover_dict["Plate"] = (
+                f"<b>Plate</b>: {plate_width} mm x "
+                f"{plate_height} mm x "
+                f"{self.plate_thickness if flag else ''} mm"
+                f"<br><b>Bolt</b> Grade: {self.bolt.bolt_grade_provided if flag else ''}, "
+                f"Dia: {bolt_dia} mm, "
+                f"Nos: {bolt_nos}"
+                f"<br><b>Weld</b> Size (Web): {self.weld_size_web if flag else ''} mm"
+            )
+            
+            self.hover_dict["Bolt"] = (
+                f"<b>Bolt</b><br>Grade: {self.bolt.bolt_grade_provided if flag else ''}"
+                f"<br>Diameter: {bolt_dia} mm"
+                f"<br>No. of Bolts: {bolt_nos}"
+            )
+            self.hover_dict["Weld"] = (
+                f"<b>Weld</b><br>Size (Web): {self.weld_size_web if flag else ''} mm"
+            )
+        except Exception:
+            pass
         
         return out_list
 

--- a/osdag_core/design_type/connection/beam_column_end_plate.py
+++ b/osdag_core/design_type/connection/beam_column_end_plate.py
@@ -594,9 +594,27 @@ class BeamColumnEndPlate(MomentConnection):
 
         # Populate Hover Dict
 
-        self.hover_dict["Bolt"] = f"<b>Bolt</b><br>Grade: {self.bolt.bolt_grade_provided if flag else ''}<br>Diameter: {int(self.bolt.bolt_diameter_provided) if flag else ''} mm<br>No. of Bolts: {int(self.bolt_numbers) if flag else ''}"
+        self.hover_dict["Column"] = f"<b>Column</b>: {self.supporting_section.designation if flag else ''}"
+        self.hover_dict["Beam"] = f"<b>Beam</b>: {self.supported_section.designation if flag else ''}"
+
+        self.hover_dict["Plate"] = (
+            f"<b>Plate</b>: {float(self.ep_width_provided) if flag else ''} mm x "
+            f"{float(self.ep_height_provided) if flag else ''} mm x "
+            f"{self.plate_thickness if flag else ''} mm"
+            f"<br><b>Bolt</b> Grade: {self.bolt.bolt_grade_provided if flag else ''}, "
+            f"Dia: {int(self.bolt.bolt_diameter_provided) if flag else ''} mm, "
+            f"Nos: {int(self.bolt_numbers) if flag else ''}"
+            f"<br><b>Weld</b> Size (Web): {self.weld_size_web if flag else ''} mm"
+        )
         
-        self.hover_dict["Plate"]= f"Plate: {float(self.ep_width_provided) if flag else ''} mm x {float(self.ep_height_provided) if flag else ''} mm x {self.plate_thickness if flag else ''} mm"
+        self.hover_dict["Bolt"] = (
+            f"<b>Bolt</b><br>Grade: {self.bolt.bolt_grade_provided if flag else ''}"
+            f"<br>Diameter: {int(self.bolt.bolt_diameter_provided) if flag else ''} mm"
+            f"<br>No. of Bolts: {int(self.bolt_numbers) if flag else ''}"
+        )
+        self.hover_dict["Weld"] = (
+            f"<b>Weld</b><br>Size (Web): {self.weld_size_web if flag else ''} mm"
+        )
         
         return out_list
 

--- a/osdag_core/design_type/connection/beam_cover_plate.py
+++ b/osdag_core/design_type/connection/beam_cover_plate.py
@@ -776,40 +776,43 @@ class BeamCoverPlate(MomentConnection):
         # out_list.append(t20)
         
         # Populate hover dict
+        try:
+            # Beam
+            self.hover_dict["Beam"] = (
+                f"<b>Beam</b><br>"
+                f"Section: {self.section.designation if flag else ''}<br>"
+                f"Depth: {self.section.depth if flag else ''} mm<br>"
+                f"Flange Width: {self.section.flange_width if flag else ''} mm<br>"
+                f"Web Thickness: {self.section.web_thickness if flag else ''} mm<br>"
+                f"Flange Thickness: {self.section.flange_thickness if flag else ''} mm"
+            )
 
-        # Beam
-        self.hover_dict["Beam"] = (
-            f"<b>Beam</b><br>"
-            f"Section: {self.section.designation if flag else ''}<br>"
-            f"Depth: {self.section.depth if flag else ''} mm<br>"
-            f"Flange Width: {self.section.flange_width if flag else ''} mm<br>"
-            f"Web Thickness: {self.section.web_thickness if flag else ''} mm<br>"
-            f"Flange Thickness: {self.section.flange_thickness if flag else ''} mm"
-        )
+            # Cover Plates (Flange + Web)
+            cover_plate_info = (
+                f"<b>Cover Plates</b><br>"
+                f"Flange Plate: {self.flange_plate.length if flag else ''} × "
+                f"{self.flange_plate.height if flag else ''} × "
+                f"{self.flange_out_plate_tk if flag else ''} mm<br>"
+                f"Inner Flange Plate: {self.plate_in_len if flag else ''} × "
+                f"{self.flange_plate.Innerheight if flag else ''} × "
+                f"{self.flange_in_plate_tk if flag else ''} mm<br>"
+                f"Web Plate: {self.web_plate.length if flag else ''} × "
+                f"{self.web_plate.height if flag else ''} × "
+                f"{self.web_plate.thickness_provided if flag else ''} mm"
+            )
+            self.hover_dict["Plate"] = cover_plate_info
+            self.hover_dict["Cover Plate"] = cover_plate_info  # alias for SmartPart.jsx 'coverplate' mesh
 
-        # Cover Plates (Flange + Web)
-        self.hover_dict["Plate"] = (
-            f"<b>Cover Plates</b><br>"
-            f"Flange Plate: {self.flange_plate.length if flag else ''} × "
-            f"{self.flange_plate.height if flag else ''} × "
-            f"{self.flange_out_plate_tk if flag else ''} mm<br>"
-            f"Inner Flange Plate: {self.plate_in_len if flag else ''} × "
-            f"{self.flange_plate.Innerheight if flag else ''} × "
-            f"{self.flange_in_plate_tk if flag else ''} mm<br>"
-            f"Web Plate: {self.web_plate.length if flag else ''} × "
-            f"{self.web_plate.height if flag else ''} × "
-            f"{self.web_plate.thickness_provided if flag else ''} mm"
-        )
-
-        # Bolts
-        self.hover_dict["Bolt"] = (
-            f"<b>Bolts</b><br>"
-            f"Diameter: {self.bolt.bolt_diameter_provided if flag else ''} mm<br>"
-            f"Grade: {self.bolt.bolt_grade_provided if flag else ''}<br>"
-            f"Flange Bolts: {self.flange_plate.bolts_required if flag else ''}<br>"
-            f"Web Bolts: {self.web_plate.bolts_required if flag else ''}"
-        )
-
+            # Bolts
+            self.hover_dict["Bolt"] = (
+                f"<b>Bolts</b><br>"
+                f"Diameter: {self.bolt.bolt_diameter_provided if flag else ''} mm<br>"
+                f"Grade: {self.bolt.bolt_grade_provided if flag else ''}<br>"
+                f"Flange Bolts: {self.flange_plate.bolts_required if flag else ''}<br>"
+                f"Web Bolts: {self.web_plate.bolts_required if flag else ''}"
+            )
+        except Exception:
+            pass
 
         return out_list
 

--- a/osdag_core/design_type/connection/beam_cover_plate_weld.py
+++ b/osdag_core/design_type/connection/beam_cover_plate_weld.py
@@ -600,38 +600,42 @@ class BeamCoverPlateWeld(MomentConnection):
         out_list.append(t20)
         
         # Populate hover dict
+        try:
+            # Beam
+            self.hover_dict["Beam"] = (
+                f"<b>Beam</b><br>"
+                f"Section: {self.section.designation if flag else ''}<br>"
+                f"Depth: {self.section.depth if flag else ''} mm<br>"
+                f"Flange Width: {self.section.flange_width if flag else ''} mm<br>"
+                f"Web Thickness: {self.section.web_thickness if flag else ''} mm<br>"
+                f"Flange Thickness: {self.section.flange_thickness if flag else ''} mm"
+            )
 
-        # Beam
-        self.hover_dict["Beam"] = (
-            f"<b>Beam</b><br>"
-            f"Section: {self.section.designation if flag else ''}<br>"
-            f"Depth: {self.section.depth if flag else ''} mm<br>"
-            f"Flange Width: {self.section.flange_width if flag else ''} mm<br>"
-            f"Web Thickness: {self.section.web_thickness if flag else ''} mm<br>"
-            f"Flange Thickness: {self.section.flange_thickness if flag else ''} mm"
-        )
+            # Cover Plates (Flange + Web)
+            cover_plate_info = (
+                f"<b>Cover Plates</b><br>"
+                f"Flange Plate: {self.flange_plate.length if flag else ''} × "
+                f"{self.flange_plate.height if flag else ''} × "
+                f"{self.flange_out_plate_tk if flag else ''} mm<br>"
+                f"Inner Flange Plate: {self.plate_in_len if flag else ''} × "
+                f"{self.flange_plate.Innerheight if flag else ''} × "
+                f"{self.flange_in_plate_tk if flag else ''} mm<br>"
+                f"Web Plate: {self.web_plate.length if flag else ''} × "
+                f"{self.web_plate.height if flag else ''} × "
+                f"{self.web_plate.thickness_provided if flag else ''} mm"
+            )
+            self.hover_dict["Plate"] = cover_plate_info
+            self.hover_dict["Cover Plate"] = cover_plate_info  # alias for SmartPart.jsx 'coverplate' mesh
 
-        # Cover Plates (Flange + Web)
-        self.hover_dict["Plate"] = (
-            f"<b>Cover Plates</b><br>"
-            f"Flange Plate: {self.flange_plate.length if flag else ''} × "
-            f"{self.flange_plate.height if flag else ''} × "
-            f"{self.flange_out_plate_tk if flag else ''} mm<br>"
-            f"Inner Flange Plate: {self.plate_in_len if flag else ''} × "
-            f"{self.flange_plate.Innerheight if flag else ''} × "
-            f"{self.flange_in_plate_tk if flag else ''} mm<br>"
-            f"Web Plate: {self.web_plate.length if flag else ''} × "
-            f"{self.web_plate.height if flag else ''} × "
-            f"{self.web_plate.thickness_provided if flag else ''} mm"
-        )
-
-        # Weld
-        self.hover_dict["Weld"] = (
-            f"<b>Weld</b><br>"
-            f"Flange Weld Size: {self.flange_weld.size if flag else ''} mm<br>"
-            f"Web Weld Size: {self.web_weld.size if flag else ''} mm<br>"
-            f"Weld Type: Fillet Weld"
-        )
+            # Weld
+            self.hover_dict["Weld"] = (
+                f"<b>Weld</b><br>"
+                f"Flange Weld Size: {self.flange_weld.size if flag else ''} mm<br>"
+                f"Web Weld Size: {self.web_weld.size if flag else ''} mm<br>"
+                f"Weld Type: Fillet Weld"
+            )
+        except Exception:
+            pass
 
         return out_list
 

--- a/osdag_core/design_type/connection/butt_joint_bolted.py
+++ b/osdag_core/design_type/connection/butt_joint_bolted.py
@@ -403,45 +403,48 @@ class ButtJointBolted(MomentConnection):
         out_list.append(t20)
 
         # Populate Hover Dict (Butt Joint Bolted)
-        self.hover_dict["Plate 1"] = (
-            f"<b>Plate 1</b><br>"
-            f"Width: {round(float(self.plate1.height), 2) if flag else ''} mm<br>"
-            f"Thickness: {round(float(self.plate1.thickness_provided), 2) if flag and self.plate1.thickness_provided else ''} mm"
-        )
-
-        self.hover_dict["Plate 2"] = (
-            f"<b>Plate 2</b><br>"
-            f"Width: {round(float(self.plate2.height), 2) if flag else ''} mm<br>"
-            f"Thickness: {round(float(self.plate2.thickness_provided), 2) if flag and self.plate2.thickness_provided else ''} mm"
-        )
-
-        self.hover_dict["Cover Plate"] = (
-            f"<b>Cover Plate</b><br>"
-            f"Width: {round(float(self.platec.height), 2) if flag else ''} mm<br>"
-            f"Thickness: {round(float(self.platec.thickness_provided), 2) if flag and self.platec.thickness_provided else ''} mm"
-        )
-
-        # Packing plate - only show if thickness > 0
-        packing_thk = getattr(self, 'packing_plate_thickness', 0.0)
-        if flag and packing_thk > 0:
-            self.hover_dict["Packing Plate"] = (
-                f"<b>Packing Plate</b><br>"
-                f"Width: {round(float(self.platec.height), 2)} mm<br>"
-                f"Thickness: {round(float(packing_thk), 2)} mm"
-            )
-        else:
-            self.hover_dict["Packing Plate"] = (
-                f"<b>Packing Plate</b><br>"
-                f"Not required for this configuration"
+        try:
+            self.hover_dict["Plate 1"] = (
+                f"<b>Plate 1</b><br>"
+                f"Width: {round(float(self.plate1.height), 2) if flag else ''} mm<br>"
+                f"Thickness: {round(float(self.plate1.thickness_provided), 2) if flag and self.plate1.thickness_provided else ''} mm"
             )
 
-        self.hover_dict["Bolt"] = (
-            f"<b>Bolts</b><br>"
-            f"Grade: {self.bolt.bolt_grade_provided if flag else ''}<br>"
-            f"Diameter: {int(self.bolt.bolt_diameter_provided) if flag else ''} mm<br>"
-            f"No. of Bolts: "
-            f"{self.number_bolts if flag else ''}"
-        )
+            self.hover_dict["Plate 2"] = (
+                f"<b>Plate 2</b><br>"
+                f"Width: {round(float(self.plate2.height), 2) if flag else ''} mm<br>"
+                f"Thickness: {round(float(self.plate2.thickness_provided), 2) if flag and self.plate2.thickness_provided else ''} mm"
+            )
+
+            self.hover_dict["Cover Plate"] = (
+                f"<b>Cover Plate</b><br>"
+                f"Width: {round(float(self.platec.height), 2) if flag else ''} mm<br>"
+                f"Thickness: {round(float(self.platec.thickness_provided), 2) if flag and self.platec.thickness_provided else ''} mm"
+            )
+
+            # Packing plate - only show if thickness > 0
+            packing_thk = getattr(self, 'packing_plate_thickness', 0.0)
+            if flag and packing_thk > 0:
+                self.hover_dict["Packing Plate"] = (
+                    f"<b>Packing Plate</b><br>"
+                    f"Width: {round(float(self.platec.height), 2)} mm<br>"
+                    f"Thickness: {round(float(packing_thk), 2)} mm"
+                )
+            else:
+                self.hover_dict["Packing Plate"] = (
+                    f"<b>Packing Plate</b><br>"
+                    f"Not required for this configuration"
+                )
+
+            self.hover_dict["Bolt"] = (
+                f"<b>Bolts</b><br>"
+                f"Grade: {self.bolt.bolt_grade_provided if flag else ''}<br>"
+                f"Diameter: {int(self.bolt.bolt_diameter_provided) if flag else ''} mm<br>"
+                f"No. of Bolts: "
+                f"{self.number_bolts if flag else ''}"
+            )
+        except Exception:
+            pass
         return out_list
 
     @staticmethod

--- a/osdag_core/design_type/connection/butt_joint_welded.py
+++ b/osdag_core/design_type/connection/butt_joint_welded.py
@@ -427,43 +427,46 @@ class ButtJointWelded(MomentConnection):
         cover_thk = getattr(self, 'calculated_cover_plate_thickness', 0)
         packing_thk = getattr(self, 'packing_plate_thickness', 0)
         
-        self.hover_dict["Plate 1"] = (
-            f"<b>Plate 1</b><br>"
-            f"Width: {round(float(plate_width), 2) if flag and plate_width else ''} mm<br>"
-            f"Thickness: {round(float(plate1_thk), 2) if flag and plate1_thk else ''} mm"
-        )
-
-        self.hover_dict["Plate 2"] = (
-            f"<b>Plate 2</b><br>"
-            f"Width: {round(float(plate_width), 2) if flag and plate_width else ''} mm<br>"
-            f"Thickness: {round(float(plate2_thk), 2) if flag and plate2_thk else ''} mm"
-        )
-
-        self.hover_dict["Cover Plate"] = (
-            f"<b>Cover Plate</b><br>"
-            f"Width: {round(float(plate_width), 2) if flag and plate_width else ''} mm<br>"
-            f"Thickness: {round(float(cover_thk), 2) if flag and cover_thk else ''} mm"
-        )
-
-        # Packing plate - only show if thickness > 0
-        if flag and packing_thk > 0:
-            self.hover_dict["Packing Plate"] = (
-                f"<b>Packing Plate</b><br>"
-                f"Width: {round(float(plate_width), 2)} mm<br>"
-                f"Thickness: {round(float(packing_thk), 2)} mm"
-            )
-        else:
-            self.hover_dict["Packing Plate"] = (
-                f"<b>Packing Plate</b><br>"
-                f"Not required for this configuration"
+        try:
+            self.hover_dict["Plate 1"] = (
+                f"<b>Plate 1</b><br>"
+                f"Width: {round(float(plate_width), 2) if flag and plate_width else ''} mm<br>"
+                f"Thickness: {round(float(plate1_thk), 2) if flag and plate1_thk else ''} mm"
             )
 
-        self.hover_dict["Weld"] = (
-            f"<b>Fillet Weld</b><br>"
-            f"Size: {round(float(self.weld_size), 1) if flag and self.weld_size else ''} mm<br>"
-            f"Type: {'Shop weld' if flag else ''}<br>"
-            f"Effective Length: {round(float(self.weld_length_effective), 1) if flag and hasattr(self, 'weld_length_effective') and self.weld_length_effective else ''} mm"
-        )
+            self.hover_dict["Plate 2"] = (
+                f"<b>Plate 2</b><br>"
+                f"Width: {round(float(plate_width), 2) if flag and plate_width else ''} mm<br>"
+                f"Thickness: {round(float(plate2_thk), 2) if flag and plate2_thk else ''} mm"
+            )
+
+            self.hover_dict["Cover Plate"] = (
+                f"<b>Cover Plate</b><br>"
+                f"Width: {round(float(plate_width), 2) if flag and plate_width else ''} mm<br>"
+                f"Thickness: {round(float(cover_thk), 2) if flag and cover_thk else ''} mm"
+            )
+
+            # Packing plate - only show if thickness > 0
+            if flag and packing_thk > 0:
+                self.hover_dict["Packing Plate"] = (
+                    f"<b>Packing Plate</b><br>"
+                    f"Width: {round(float(plate_width), 2)} mm<br>"
+                    f"Thickness: {round(float(packing_thk), 2)} mm"
+                )
+            else:
+                self.hover_dict["Packing Plate"] = (
+                    f"<b>Packing Plate</b><br>"
+                    f"Not required for this configuration"
+                )
+
+            self.hover_dict["Weld"] = (
+                f"<b>Fillet Weld</b><br>"
+                f"Size: {round(float(self.weld_size), 1) if flag and self.weld_size else ''} mm<br>"
+                f"Type: {'Shop weld' if flag else ''}<br>"
+                f"Effective Length: {round(float(self.weld_length_effective), 1) if flag and hasattr(self, 'weld_length_effective') and self.weld_length_effective else ''} mm"
+            )
+        except Exception:
+            pass
 
         return out_list
 

--- a/osdag_core/design_type/connection/cleat_angle_connection.py
+++ b/osdag_core/design_type/connection/cleat_angle_connection.py
@@ -437,21 +437,25 @@ class CleatAngleConnection(ShearConnection):
         """"""""""""""""""""""""""""""""""""""""""""""""""""""""
         
         # Populate hover dict
-        self.hover_dict["Column"] = f"Column: {self.supporting_section.designation if flag else ''}"
-        self.hover_dict["Beam"] = f"Beam: {self.supported_section.designation if flag else ''}"
+        self.hover_dict["Column"] = f"<b>Column</b><br>{self.supporting_section.designation if flag else ''}"
+        self.hover_dict["Beam"] = f"<b>Beam</b><br>{self.supported_section.designation if flag else ''}"
 
         # In the web 3D viewer, bolts are fused into the Angle STL mesh.
-        bolt_count = int(self.spting_leg.bolt_line) * int(self.spting_leg.bolts_one_line) if flag else ''
-        self.hover_dict["Angle"] = (
-            f"<b>Angle</b>: ISA {self.cleat.designation if flag else ''}"
-            f"<br><b>Bolt</b> Grade: {self.bolt.bolt_grade_provided if flag else ''}, "
-            f"Dia: {int(self.bolt.bolt_diameter_provided) if flag else ''} mm, "
+        try:
+            bolt_count = int(self.spting_leg.bolt_line) * int(self.spting_leg.bolts_one_line) if flag else ''
+        except (ValueError, TypeError, AttributeError):
+            bolt_count = ''
+        
+        self.hover_dict["Cleat Angle"] = (
+            f"<b>Cleat Angle</b><br>ISA {self.cleat.designation if flag else ''}"
+            f"<br>Bolt Grade: {self.bolt.bolt_grade_provided if flag else ''}, "
+            f"Dia: {self.bolt.bolt_diameter_provided if flag else ''} mm, "
             f"Nos: {bolt_count}"
         )
         # Keep separate key for future per-part meshes
         self.hover_dict["Bolt"] = (
             f"<b>Bolt</b><br>Grade: {self.bolt.bolt_grade_provided if flag else ''}"
-            f"<br>Diameter: {int(self.bolt.bolt_diameter_provided) if flag else ''} mm"
+            f"<br>Diameter: {self.bolt.bolt_diameter_provided if flag else ''} mm"
             f"<br>No. of Bolts: {bolt_count}"
         )
         

--- a/osdag_core/design_type/connection/cleat_angle_connection.py
+++ b/osdag_core/design_type/connection/cleat_angle_connection.py
@@ -437,9 +437,23 @@ class CleatAngleConnection(ShearConnection):
         """"""""""""""""""""""""""""""""""""""""""""""""""""""""
         
         # Populate hover dict
-        self.hover_dict["Bolt"] = f"<b>Bolt</b><br>Grade: {self.bolt.bolt_grade_provided if flag else ''}<br>Diameter: {int(self.bolt.bolt_diameter_provided) if flag else ''} mm<br>No. of Bolts: {int(self.spting_leg.bolt_line)*int(self.spting_leg.bolts_one_line) if flag else ''}"
-        
-        self.hover_dict["Angle"]= f"Angle: ISA {self.cleat.designation if flag else ''}"
+        self.hover_dict["Column"] = f"Column: {self.supporting_section.designation if flag else ''}"
+        self.hover_dict["Beam"] = f"Beam: {self.supported_section.designation if flag else ''}"
+
+        # In the web 3D viewer, bolts are fused into the Angle STL mesh.
+        bolt_count = int(self.spting_leg.bolt_line) * int(self.spting_leg.bolts_one_line) if flag else ''
+        self.hover_dict["Angle"] = (
+            f"<b>Angle</b>: ISA {self.cleat.designation if flag else ''}"
+            f"<br><b>Bolt</b> Grade: {self.bolt.bolt_grade_provided if flag else ''}, "
+            f"Dia: {int(self.bolt.bolt_diameter_provided) if flag else ''} mm, "
+            f"Nos: {bolt_count}"
+        )
+        # Keep separate key for future per-part meshes
+        self.hover_dict["Bolt"] = (
+            f"<b>Bolt</b><br>Grade: {self.bolt.bolt_grade_provided if flag else ''}"
+            f"<br>Diameter: {int(self.bolt.bolt_diameter_provided) if flag else ''} mm"
+            f"<br>No. of Bolts: {bolt_count}"
+        )
         
         return out_list
 

--- a/osdag_core/design_type/connection/column_cover_plate.py
+++ b/osdag_core/design_type/connection/column_cover_plate.py
@@ -717,11 +717,11 @@ class ColumnCoverPlate(MomentConnection):
         out_list.append(t18)
 
         t19 = (KEY_FLANGE_PLATE_LENGTH, KEY_DISP_FLANGE_PLATE_LENGTH, TYPE_TEXTBOX,
-               self.plate_out_len if flag else '', True)
+               getattr(self, 'plate_out_len', '') if flag else '', True)
         out_list.append(t19)
 
         t20 = (KEY_FLANGEPLATE_THICKNESS, KEY_DISP_FLANGESPLATE_THICKNESS, TYPE_TEXTBOX,
-               int(self.flange_out_plate_tk) if flag else '', True)
+               int(getattr(self, 'flange_out_plate_tk', 0) or 0) if flag else '', True)
         out_list.append(t20)
         t21 = (
         KEY_FLANGE_SPACING, KEY_DISP_FLANGE_SPACING, TYPE_OUT_BUTTON, ['Flange Spacing Details', self.flangespacing],
@@ -739,11 +739,11 @@ class ColumnCoverPlate(MomentConnection):
         out_list.append(t18)
 
         t19 = (KEY_INNERFLANGE_PLATE_LENGTH, KEY_DISP_INNERFLANGE_PLATE_LENGTH, TYPE_TEXTBOX,
-               self.plate_in_len if flag else '', False)
+               getattr(self, 'plate_in_len', '') if flag else '', False)
         out_list.append(t19)
         # if flag is True:
         t20 = (KEY_INNERFLANGEPLATE_THICKNESS, KEY_DISP_INNERFLANGESPLATE_THICKNESS, TYPE_TEXTBOX,
-               self.flange_in_plate_tk if flag else '', False)
+               getattr(self, 'flange_in_plate_tk', '') if flag else '', False)
         out_list.append(t20)
         
         # Populate hover dict
@@ -759,15 +759,17 @@ class ColumnCoverPlate(MomentConnection):
         )
 
         # Cover Plates (Flange + Web)
-        self.hover_dict["Plate"] = (
+        cover_plate_info = (
             f"<b>Cover Plates</b><br>"
             f"Flange Plate: {self.flange_plate.length if flag else ''} × "
             f"{self.flange_plate.height if flag else ''} × "
-            f"{self.flange_plate.thickness_provided if flag else ''} mm<br>"
+            f"{getattr(self, 'flange_out_plate_tk', self.flange_plate.thickness_provided) if flag else ''} mm<br>"
             f"Web Plate: {self.web_plate.length if flag else ''} × "
             f"{self.web_plate.height if flag else ''} × "
             f"{self.web_plate.thickness_provided if flag else ''} mm"
         )
+        self.hover_dict["Plate"] = cover_plate_info
+        self.hover_dict["Cover Plate"] = cover_plate_info  # alias for SmartPart.jsx 'coverplate' mesh
 
         # Bolts
         self.hover_dict["Bolt"] = (

--- a/osdag_core/design_type/connection/column_cover_plate_weld.py
+++ b/osdag_core/design_type/connection/column_cover_plate_weld.py
@@ -466,15 +466,15 @@ class ColumnCoverPlateWeld(MomentConnection):
                self.web_weld.strength if flag else '')
         web_weld_details.append(t15)  # in N/mm
         t5 = (
-        KEY_REDUCTION_LONG_JOINT, KEY_DISP_REDUCTION, TYPE_TEXTBOX, round(self.Reduction_factor_web, 2) if flag else '',
+        KEY_REDUCTION_LONG_JOINT, KEY_DISP_REDUCTION, TYPE_TEXTBOX, round(getattr(self, 'Reduction_factor_web', 1), 2) if flag else '',
         True)
         web_weld_details.append(t5)
 
         t10 = (KEY_OUT_WELD_STRENGTH_RED, KEY_OUT_DISP_WELD_STRENGTH_RED, TYPE_TEXTBOX,
-               round(self.web_weld.strength_red, 2) if flag else '',
+               round(getattr(self.web_weld, 'strength_red', 0), 2) if flag else '',
                True)
         web_weld_details.append(t10)
-        t16 = (KEY_WEB_WELD_STRESS, KEY_WEB_DISP_WELD_STRESS, TYPE_TEXTBOX, self.web_weld.stress if flag else '')
+        t16 = (KEY_WEB_WELD_STRESS, KEY_WEB_DISP_WELD_STRESS, TYPE_TEXTBOX, getattr(self.web_weld, 'stress', '') if flag else '')
         web_weld_details.append(t16)
 
         return web_weld_details
@@ -516,15 +516,15 @@ class ColumnCoverPlateWeld(MomentConnection):
                self.flange_weld.strength if flag else '')
         flange_weld_details.append(t15)  # in N/mm
         t5 = (KEY_REDUCTION_LONG_JOINT, KEY_DISP_REDUCTION, TYPE_TEXTBOX,
-              round(self.Reduction_factor_flange, 2) if flag else '',
+              round(getattr(self, 'Reduction_factor_flange', 1), 2) if flag else '',
               True)
         flange_weld_details.append(t5)
         t10 = (KEY_OUT_WELD_STRENGTH_RED, KEY_OUT_DISP_WELD_STRENGTH_RED, TYPE_TEXTBOX,
-               round(self.flange_weld.strength_red, 2) if flag else '',
+               round(getattr(self.flange_weld, 'strength_red', 0), 2) if flag else '',
                True)
         flange_weld_details.append(t10)
         t16 = (
-        KEY_FLANGE_WELD_STRESS, KEY_FLANGE_DISP_WELD_STRESS, TYPE_TEXTBOX, self.flange_weld.stress if flag else '')
+        KEY_FLANGE_WELD_STRESS, KEY_FLANGE_DISP_WELD_STRESS, TYPE_TEXTBOX, getattr(self.flange_weld, 'stress', '') if flag else '')
         flange_weld_details.append(t16)  # in N/mm
 
         return flange_weld_details
@@ -614,12 +614,12 @@ class ColumnCoverPlateWeld(MomentConnection):
         out_list.append(t18)
 
         t19 = (KEY_FLANGE_PLATE_LENGTH, KEY_DISP_FLANGE_PLATE_LENGTH, TYPE_TEXTBOX,
-               self.plate_out_len if flag else '', True)
+               getattr(self, 'plate_out_len', '') if flag else '', True)
 
         out_list.append(t19)
 
         t20 = (KEY_FLANGEPLATE_THICKNESS, KEY_DISP_FLANGESPLATE_THICKNESS, TYPE_TEXTBOX,
-               int(self.flange_out_plate_tk) if flag else '', True)
+               int(getattr(self, 'flange_out_plate_tk', 0) or 0) if flag else '', True)
         out_list.append(t20)
 
         t21 = (
@@ -644,12 +644,12 @@ class ColumnCoverPlateWeld(MomentConnection):
 
         t19 = (
             KEY_INNERFLANGE_PLATE_LENGTH, KEY_DISP_INNERFLANGE_PLATE_LENGTH, TYPE_TEXTBOX,
-            self.plate_in_len if flag else '',  False)
+            getattr(self, 'plate_in_len', '') if flag else '',  False)
 
         out_list.append(t19)
 
         t20 = (KEY_INNERFLANGEPLATE_THICKNESS, KEY_DISP_INNERFLANGESPLATE_THICKNESS, TYPE_TEXTBOX,
-               self.flange_in_plate_tk if flag else '', False)
+               getattr(self, 'flange_in_plate_tk', '') if flag else '', False)
         out_list.append(t20)
 
         # t21 = (KEY_INNERFLANGE_WELD_DETAILS, KEY_DISP_INNERFLANGE_WELD_DETAILS, TYPE_OUT_BUTTON,
@@ -678,18 +678,20 @@ class ColumnCoverPlateWeld(MomentConnection):
         )
 
         # Cover Plates (Flange + Web)
-        self.hover_dict["Plate"] = (
+        cover_plate_info = (
             f"<b>Cover Plates</b><br>"
             f"Flange Plate: {self.flange_plate.length if flag else ''} × "
             f"{self.flange_plate.height if flag else ''} × "
-            f"{self.flange_out_plate_tk if flag else ''} mm<br>"
-            f"Inner Flange Plate: {self.plate_in_len if flag else ''} × "
+            f"{getattr(self, 'flange_out_plate_tk', self.flange_plate.thickness_provided) if flag else ''} mm<br>"
+            f"Inner Flange Plate: {getattr(self, 'plate_in_len', '') if flag else ''} × "
             f"{self.flange_plate.Innerheight if flag else ''} × "
-            f"{self.flange_in_plate_tk if flag else ''} mm<br>"
+            f"{getattr(self, 'flange_in_plate_tk', '') if flag else ''} mm<br>"
             f"Web Plate: {self.web_plate.length if flag else ''} × "
             f"{self.web_plate.height if flag else ''} × "
             f"{self.web_plate.thickness_provided if flag else ''} mm"
         )
+        self.hover_dict["Plate"] = cover_plate_info
+        self.hover_dict["Cover Plate"] = cover_plate_info  # alias for SmartPart.jsx 'coverplate' mesh
 
         # Weld
         self.hover_dict["Weld"] = (

--- a/osdag_core/design_type/connection/column_end_plate.py
+++ b/osdag_core/design_type/connection/column_end_plate.py
@@ -591,22 +591,17 @@ class ColumnEndPlate(MomentConnection):
         # Populate hover dict
 
         # Column
-        self.hover_dict["Column"] = (
-            f"<b>Column</b><br>"
-            f"Section: {self.section.designation if flag else ''}<br>"
-            f"Depth: {self.section.depth if flag else ''} mm<br>"
-            f"Flange Width: {self.section.flange_width if flag else ''} mm<br>"
-            f"Web Thickness: {self.section.web_thickness if flag else ''} mm<br>"
-            f"Flange Thickness: {self.section.flange_thickness if flag else ''} mm"
-        )
+        self.hover_dict["Column"] = f"<b>Column</b>: {self.section.designation if flag else ''}"
 
         # End Plate
         self.hover_dict["Plate"] = (
-            f"<b>End Plate</b><br>"
-            f"Width: {self.plate_width if flag else ''} mm<br>"
-            f"Height: {self.plate_height if flag else ''} mm<br>"
-            f"Thickness: {self.plate_thickness_provided if flag else ''} mm<br>"
-            f"Moment Capacity: {round(self.m_dp_prov / 1e6, 2) if flag else ''} kNm"
+            f"<b>End Plate</b>: {self.plate_width if flag else ''} mm x "
+            f"{self.plate_height if flag else ''} mm x "
+            f"{self.plate_thickness_provided if flag else ''} mm"
+            f"<br><b>Bolt</b> Grade: {self.bolt_grade_provided if flag else ''}, "
+            f"Dia: {self.bolt_diam_provided if flag else ''} mm, "
+            f"Nos: {self.no_bolts if flag else ''}"
+            f"<br><b>Weld</b> Size: {self.weld_size_prov if flag else ''} mm"
         )
 
         # Bolts

--- a/osdag_core/design_type/connection/column_end_plate.py
+++ b/osdag_core/design_type/connection/column_end_plate.py
@@ -589,45 +589,47 @@ class ColumnEndPlate(MomentConnection):
         # out_list.append(t22)
         
         # Populate hover dict
+        try:
+            # Column
+            self.hover_dict["Column"] = f"<b>Column</b>: {self.section.designation if flag else ''}"
 
-        # Column
-        self.hover_dict["Column"] = f"<b>Column</b>: {self.section.designation if flag else ''}"
+            # End Plate
+            self.hover_dict["Plate"] = (
+                f"<b>End Plate</b>: {self.plate_width if flag else ''} mm x "
+                f"{self.plate_height if flag else ''} mm x "
+                f"{self.plate_thickness_provided if flag else ''} mm"
+                f"<br><b>Bolt</b> Grade: {self.bolt_grade_provided if flag else ''}, "
+                f"Dia: {self.bolt_diam_provided if flag else ''} mm, "
+                f"Nos: {self.no_bolts if flag else ''}"
+                f"<br><b>Weld</b> Size: {self.weld_size_prov if flag else ''} mm"
+            )
 
-        # End Plate
-        self.hover_dict["Plate"] = (
-            f"<b>End Plate</b>: {self.plate_width if flag else ''} mm x "
-            f"{self.plate_height if flag else ''} mm x "
-            f"{self.plate_thickness_provided if flag else ''} mm"
-            f"<br><b>Bolt</b> Grade: {self.bolt_grade_provided if flag else ''}, "
-            f"Dia: {self.bolt_diam_provided if flag else ''} mm, "
-            f"Nos: {self.no_bolts if flag else ''}"
-            f"<br><b>Weld</b> Size: {self.weld_size_prov if flag else ''} mm"
-        )
+            # Bolts
+            self.hover_dict["Bolt"] = (
+                f"<b>Bolts</b><br>"
+                f"Diameter: {self.bolt_diam_provided if flag else ''} mm<br>"
+                f"Grade: {self.bolt_grade_provided if flag else ''}<br>"
+                f"No. of Bolts: {self.no_bolts if flag else ''}<br>"
+                f"Shear Capacity: {round(self.bolt_cap / 1000, 2) if flag else ''} kN"
+            )
 
-        # Bolts
-        self.hover_dict["Bolt"] = (
-            f"<b>Bolts</b><br>"
-            f"Diameter: {self.bolt_diam_provided if flag else ''} mm<br>"
-            f"Grade: {self.bolt_grade_provided if flag else ''}<br>"
-            f"Total Bolts: {self.no_bolts if flag else ''}<br>"
-            f"Shear Capacity: {round(self.bolt_cap / 1000, 2) if flag else ''} kN"
-        )
+            # Welds
+            self.hover_dict["Weld"] = (
+                f"<b>Weld</b><br>"
+                f"Type: {self.weld_type if flag else ''}<br>"
+                f"Stiffener Weld Type: Groove Weld<br>"
+                f"Weld Size: {self.weld_size_prov if flag else ''} mm"
+            )
 
-        # Welds
-        self.hover_dict["Weld"] = (
-            f"<b>Weld</b><br>"
-            f"Type: {self.weld_type if flag else ''}<br>"
-            f"Stiffener Weld Type: Groove Weld<br>"
-            f"Weld Size: {self.weld_size_prov if flag else ''} mm"
-        )
-
-        # Stiffener
-        self.hover_dict["Stiffener"] = (
-            f"<b>Stiffener Plate</b><br>"
-            f"Height: {self.stiff_ht if flag else ''} mm<br>"
-            f"Width: {self.stiff_wt if flag else ''} mm<br>"
-            f"Thickness: {self.t_s if flag else ''} mm"
-        )
+            # Stiffener
+            self.hover_dict["Stiffener"] = (
+                f"<b>Stiffener Plate</b><br>"
+                f"Height: {self.stiff_ht if flag else ''} mm<br>"
+                f"Width: {self.stiff_wt if flag else ''} mm<br>"
+                f"Thickness: {self.t_s if flag else ''} mm"
+            )
+        except Exception:
+            pass
 
         return out_list
 

--- a/osdag_core/design_type/connection/connection.py
+++ b/osdag_core/design_type/connection/connection.py
@@ -545,9 +545,15 @@ class Connection(Main):
 
             # hover labels
             if option[1] == KEY_DISP_COLSEC:
-                self.hover_dict["Column"] = f"Column: {design_dictionary[option[0]]}"
+                self.hover_dict["Column"] = (
+                    f"<b>Column</b><br>"
+                    f"{design_dictionary[option[0]]}"
+                )
             elif option[1] == KEY_DISP_BEAMSEC:
-                self.hover_dict["Beam"] = f"Beam: {design_dictionary[option[0]]}"
+                self.hover_dict["Beam"] = (
+                    f"<b>Beam</b><br>"
+                    f"{design_dictionary[option[0]]}"
+                )
 
             if option[2] == TYPE_COMBOBOX and option[0] != KEY_CONN:
                 if design_dictionary[option[0]] == 'Select Section' or design_dictionary[option[0]] == 'Select Grade':

--- a/osdag_core/design_type/connection/end_plate_connection.py
+++ b/osdag_core/design_type/connection/end_plate_connection.py
@@ -1363,25 +1363,33 @@ class EndPlateConnection(ShearConnection):
         self.hover_dict["Beam"] = f"Beam: {self.supported_section.designation if flag else ''}"
 
         # In the web 3D viewer, bolts and welds are fused into the Plate STL.
-        bolt_count = self.output[0][12] if flag else ''
+        try:
+            bolt_count = self.output[0][12] if flag and self.output else ''
+            plate_width = self.output[0][5] if flag and self.output else ''
+            plate_height = self.output[0][4] if flag and self.output else ''
+            plate_thk = self.output[0][3] if flag and self.output else ''
+            weld_size = self.output[0][23] if flag and self.output else ''
+        except (IndexError, TypeError, ValueError):
+            bolt_count = plate_width = plate_height = plate_thk = weld_size = ''
+
         self.hover_dict["Plate"] = (
-            f"<b>Plate</b>: {float(self.output[0][5]) if flag else ''} mm x "
-            f"{float(self.output[0][4]) if flag else ''} mm x "
-            f"{self.output[0][3] if flag else ''} mm"
+            f"<b>Plate</b>: {plate_width} mm x "
+            f"{plate_height} mm x "
+            f"{plate_thk} mm"
             f"<br><b>Bolt</b> Grade: {self.bolt.bolt_grade_provided if flag else ''}, "
-            f"Dia: {int(self.bolt.bolt_diameter_provided) if flag else ''} mm, "
+            f"Dia: {self.bolt.bolt_diameter_provided if flag else ''} mm, "
             f"Nos: {bolt_count}"
-            f"<br><b>Weld</b> Size: {self.output[0][23] if flag else ''} mm, "
+            f"<br><b>Weld</b> Size: {weld_size} mm, "
             f"Length: {self.plate.height if flag else ''} mm"
         )
         # Keep separate keys for future per-part meshes
         self.hover_dict["Bolt"] = (
             f"<b>Bolt</b><br>Grade: {self.bolt.bolt_grade_provided if flag else ''}"
-            f"<br>Diameter: {int(self.bolt.bolt_diameter_provided) if flag else ''} mm"
+            f"<br>Diameter: {self.bolt.bolt_diameter_provided if flag else ''} mm"
             f"<br>No. of Bolts: {bolt_count}"
         )
         self.hover_dict["Weld"] = (
-            f"<b>Weld</b><br>Size: {self.output[0][23] if flag else ''} mm"
+            f"<b>Weld</b><br>Size: {weld_size} mm"
             f"<br>Length: {self.plate.height if flag else ''} mm"
         )
 

--- a/osdag_core/design_type/connection/end_plate_connection.py
+++ b/osdag_core/design_type/connection/end_plate_connection.py
@@ -1359,11 +1359,31 @@ class EndPlateConnection(ShearConnection):
         out_list.append(t27)
 
         # Populate hover dict
-        self.hover_dict["Bolt"] = f"<b>Bolt</b><br>Grade: {self.bolt.bolt_grade_provided if flag else ''}<br>Diameter: {int(self.bolt.bolt_diameter_provided) if flag else ''} mm<br>No. of Bolts: {int(self.plate.bolts_one_line)*int(self.plate.bolt_line) if flag else ''}"
-        
-        self.hover_dict["Plate"]= f"Plate: {float(self.output[0][5]) if flag else ''} mm x {float(self.output[0][4]) if flag else ''} mm x {self.output[0][3] if flag else ''} mm"
-            
-        self.hover_dict["Weld"]= f"<b>Weld</b><br>Size: {self.output[0][23] if flag else ''} mm<br>Length: {self.plate.height if flag else ''} mm"
+        self.hover_dict["Column"] = f"Column: {self.supporting_section.designation if flag else ''}"
+        self.hover_dict["Beam"] = f"Beam: {self.supported_section.designation if flag else ''}"
+
+        # In the web 3D viewer, bolts and welds are fused into the Plate STL.
+        bolt_count = self.output[0][12] if flag else ''
+        self.hover_dict["Plate"] = (
+            f"<b>Plate</b>: {float(self.output[0][5]) if flag else ''} mm x "
+            f"{float(self.output[0][4]) if flag else ''} mm x "
+            f"{self.output[0][3] if flag else ''} mm"
+            f"<br><b>Bolt</b> Grade: {self.bolt.bolt_grade_provided if flag else ''}, "
+            f"Dia: {int(self.bolt.bolt_diameter_provided) if flag else ''} mm, "
+            f"Nos: {bolt_count}"
+            f"<br><b>Weld</b> Size: {self.output[0][23] if flag else ''} mm, "
+            f"Length: {self.plate.height if flag else ''} mm"
+        )
+        # Keep separate keys for future per-part meshes
+        self.hover_dict["Bolt"] = (
+            f"<b>Bolt</b><br>Grade: {self.bolt.bolt_grade_provided if flag else ''}"
+            f"<br>Diameter: {int(self.bolt.bolt_diameter_provided) if flag else ''} mm"
+            f"<br>No. of Bolts: {bolt_count}"
+        )
+        self.hover_dict["Weld"] = (
+            f"<b>Weld</b><br>Size: {self.output[0][23] if flag else ''} mm"
+            f"<br>Length: {self.plate.height if flag else ''} mm"
+        )
 
         # TODO: Weld Properties: End
         return out_list

--- a/osdag_core/design_type/connection/fin_plate_connection.py
+++ b/osdag_core/design_type/connection/fin_plate_connection.py
@@ -457,13 +457,17 @@ class FinPlateConnection(ShearConnection):
         # In the web 3D viewer, bolts and welds are fused into the Plate STL
         # (unlike the desktop OCC viewer which can distinguish sub-shapes).
         # So the Plate hover shows combined Plate + Bolt + Weld details.
-        bolt_count = int(self.plate.bolts_one_line) * int(self.plate.bolt_line) if flag else ''
+        try:
+            bolt_count = int(self.plate.bolts_one_line) * int(self.plate.bolt_line) if flag else ''
+        except (ValueError, TypeError, AttributeError):
+            bolt_count = ''
+            
         self.hover_dict["Plate"] = (
-            f"<b>Plate</b>: {float(self.plate.length) if flag else ''} mm x "
-            f"{float(self.plate.height) if flag else ''} mm x "
+            f"<b>Plate</b>: {self.plate.length if flag else ''} mm x "
+            f"{self.plate.height if flag else ''} mm x "
             f"{self.plate.thickness_provided if flag else ''} mm"
             f"<br><b>Bolt</b> Grade: {self.bolt.bolt_grade_provided if flag else ''}, "
-            f"Dia: {int(self.bolt.bolt_diameter_provided) if flag else ''} mm, "
+            f"Dia: {self.bolt.bolt_diameter_provided if flag else ''} mm, "
             f"Nos: {bolt_count}"
             f"<br><b>Weld</b> Size: {self.weld.size if flag else ''} mm, "
             f"Length: {self.plate.height if flag else ''} mm"
@@ -471,7 +475,7 @@ class FinPlateConnection(ShearConnection):
         # Keep separate keys for future per-part meshes
         self.hover_dict["Bolt"] = (
             f"<b>Bolt</b><br>Grade: {self.bolt.bolt_grade_provided if flag else ''}"
-            f"<br>Diameter: {int(self.bolt.bolt_diameter_provided) if flag else ''} mm"
+            f"<br>Diameter: {self.bolt.bolt_diameter_provided if flag else ''} mm"
             f"<br>No. of Bolts: {bolt_count}"
         )
         self.hover_dict["Weld"] = (

--- a/osdag_core/design_type/connection/fin_plate_connection.py
+++ b/osdag_core/design_type/connection/fin_plate_connection.py
@@ -451,13 +451,36 @@ class FinPlateConnection(ShearConnection):
         out_list.append(t16)
 
         # Populate hover dict
-        self.hover_dict["Bolt"] = f"<b>Bolt</b><br>Grade: {self.bolt.bolt_grade_provided if flag else ''}<br>Diameter: {int(self.bolt.bolt_diameter_provided) if flag else ''} mm<br>No. of Bolts: {int(self.plate.bolts_one_line)*int(self.plate.bolt_line) if flag else ''}"
-        
-        self.hover_dict["Plate"]= f"Plate: {float(self.plate.length) if flag else ''} mm x {float(self.plate.height) if flag else ''} mm x {self.plate.thickness_provided if flag else ''} mm"
-            
-        self.hover_dict["Weld"]= f"<b>Weld</b><br>Size: {self.weld.size if flag else ''} mm<br>Length: {self.plate.height if flag else ''} mm"
+        self.hover_dict["Column"] = f"Column: {self.supporting_section.designation if flag else ''}"
+        self.hover_dict["Beam"] = f"Beam: {self.supported_section.designation if flag else ''}"
+
+        # In the web 3D viewer, bolts and welds are fused into the Plate STL
+        # (unlike the desktop OCC viewer which can distinguish sub-shapes).
+        # So the Plate hover shows combined Plate + Bolt + Weld details.
+        bolt_count = int(self.plate.bolts_one_line) * int(self.plate.bolt_line) if flag else ''
+        self.hover_dict["Plate"] = (
+            f"<b>Plate</b>: {float(self.plate.length) if flag else ''} mm x "
+            f"{float(self.plate.height) if flag else ''} mm x "
+            f"{self.plate.thickness_provided if flag else ''} mm"
+            f"<br><b>Bolt</b> Grade: {self.bolt.bolt_grade_provided if flag else ''}, "
+            f"Dia: {int(self.bolt.bolt_diameter_provided) if flag else ''} mm, "
+            f"Nos: {bolt_count}"
+            f"<br><b>Weld</b> Size: {self.weld.size if flag else ''} mm, "
+            f"Length: {self.plate.height if flag else ''} mm"
+        )
+        # Keep separate keys for future per-part meshes
+        self.hover_dict["Bolt"] = (
+            f"<b>Bolt</b><br>Grade: {self.bolt.bolt_grade_provided if flag else ''}"
+            f"<br>Diameter: {int(self.bolt.bolt_diameter_provided) if flag else ''} mm"
+            f"<br>No. of Bolts: {bolt_count}"
+        )
+        self.hover_dict["Weld"] = (
+            f"<b>Weld</b><br>Size: {self.weld.size if flag else ''} mm"
+            f"<br>Length: {self.plate.height if flag else ''} mm"
+        )
 
         return out_list
+
 
     ####################################
     # Setting input values and start of Calculations

--- a/osdag_core/design_type/connection/lap_joint_bolted.py
+++ b/osdag_core/design_type/connection/lap_joint_bolted.py
@@ -379,24 +379,27 @@ class LapJointBolted(MomentConnection):
         out_list.append(t21)
 
         # Populate Hover Dict (Lap Joint Bolted)
-        self.hover_dict["Plate 1"] = (
-            f"<b>Plate 1</b><br>"
-            f"Width: {round(float(self.plate1.height), 2) if flag and self.plate1 and self.plate1.height else ''} mm<br>"
-            f"Thickness: {round(float(self.plate1.thickness_provided), 2) if flag and self.plate1 and self.plate1.thickness_provided else ''} mm"
-        )
+        try:
+            self.hover_dict["Plate 1"] = (
+                f"<b>Plate 1</b><br>"
+                f"Width: {round(float(self.plate1.height), 2) if flag and self.plate1 and self.plate1.height else ''} mm<br>"
+                f"Thickness: {round(float(self.plate1.thickness_provided), 2) if flag and self.plate1 and self.plate1.thickness_provided else ''} mm"
+            )
 
-        self.hover_dict["Plate 2"] = (
-            f"<b>Plate 2</b><br>"
-            f"Width: {round(float(self.plate2.height), 2) if flag and self.plate2 and self.plate2.height else ''} mm<br>"
-            f"Thickness: {round(float(self.plate2.thickness_provided), 2) if flag and self.plate2 and self.plate2.thickness_provided else ''} mm"
-        )
+            self.hover_dict["Plate 2"] = (
+                f"<b>Plate 2</b><br>"
+                f"Width: {round(float(self.plate2.height), 2) if flag and self.plate2 and self.plate2.height else ''} mm<br>"
+                f"Thickness: {round(float(self.plate2.thickness_provided), 2) if flag and self.plate2 and self.plate2.thickness_provided else ''} mm"
+            )
 
-        self.hover_dict["Bolt"] = (
-            f"<b>Bolts</b><br>"
-            f"Grade: {self.bolt.bolt_grade_provided if flag and self.bolt else ''}<br>"
-            f"Diameter: {int(self.bolt.bolt_diameter_provided) if flag and self.bolt else ''} mm<br>"
-            f"No. of Bolts: {self.number_bolts if flag else ''}"
-        )
+            self.hover_dict["Bolt"] = (
+                f"<b>Bolts</b><br>"
+                f"Grade: {self.bolt.bolt_grade_provided if flag and self.bolt else ''}<br>"
+                f"Diameter: {int(self.bolt.bolt_diameter_provided) if flag and self.bolt else ''} mm<br>"
+                f"No. of Bolts: {self.number_bolts if flag else ''}"
+            )
+        except Exception:
+            pass
 
         return out_list
     

--- a/osdag_core/design_type/connection/lap_joint_welded.py
+++ b/osdag_core/design_type/connection/lap_joint_welded.py
@@ -295,22 +295,25 @@ class LapJointWelded(MomentConnection):
             self.plate2.height = plate_width
             self.plate2.thickness_provided = plate2_thk
 
-        self.hover_dict["Plate 1"] = (
-            f"<b>Plate 1</b><br>"
-            f"Width: {round(float(self.plate1.height), 2) if flag and self.plate1.height else ''} mm<br>"
-            f"Thickness: {round(float(self.plate1.thickness_provided), 2) if flag and self.plate1.thickness_provided else ''} mm"
-        )
-        self.hover_dict["Plate 2"] = (
-            f"<b>Plate 2</b><br>"
-            f"Width: {round(float(self.plate2.height), 2) if flag and self.plate2.height else ''} mm<br>"
-            f"Thickness: {round(float(self.plate2.thickness_provided), 2) if flag and self.plate2.thickness_provided else ''} mm"
-        )
-        self.hover_dict["Weld"] = (
-            f"<b>Fillet Weld</b><br>"
-            f"Size: {round(float(self.weld_size), 1) if flag and self.weld_size else ''} mm<br>"
-            f"Type: {getattr(self.weld, 'type', 'Fillet') if flag else ''}<br>"
-            f"Effective Length: {round(float(self.weld_length_effective), 1) if flag and self.weld_length_effective else ''} mm"
-        )
+        try:
+            self.hover_dict["Plate 1"] = (
+                f"<b>Plate 1</b><br>"
+                f"Width: {round(float(self.plate1.height), 2) if flag and self.plate1.height else ''} mm<br>"
+                f"Thickness: {round(float(self.plate1.thickness_provided), 2) if flag and self.plate1.thickness_provided else ''} mm"
+            )
+            self.hover_dict["Plate 2"] = (
+                f"<b>Plate 2</b><br>"
+                f"Width: {round(float(self.plate2.height), 2) if flag and self.plate2.height else ''} mm<br>"
+                f"Thickness: {round(float(self.plate2.thickness_provided), 2) if flag and self.plate2.thickness_provided else ''} mm"
+            )
+            self.hover_dict["Weld"] = (
+                f"<b>Fillet Weld</b><br>"
+                f"Size: {round(float(self.weld_size), 1) if flag and self.weld_size else ''} mm<br>"
+                f"Type: {getattr(self.weld, 'type', 'Fillet') if flag else ''}<br>"
+                f"Effective Length: {round(float(self.weld_length_effective), 1) if flag and self.weld_length_effective else ''} mm"
+            )
+        except Exception:
+            pass
 
         return out_list
 

--- a/osdag_core/design_type/connection/seated_angle_connection.py
+++ b/osdag_core/design_type/connection/seated_angle_connection.py
@@ -531,22 +531,25 @@ class SeatedAngleConnection(ShearConnection):
         """     Top Angle Properties: End     """
         """"""""""""""""""""""""""""""""""""""""""""""""""""""
         # Populate hover dict
-        self.hover_dict["Column"] = f"Column: {self.supporting_section.designation if flag else ''}"
-        self.hover_dict["Beam"] = f"Beam: {self.supported_section.designation if flag else ''}"
+        self.hover_dict["Column"] = f"<b>Column</b><br>{self.supporting_section.designation if flag else ''}"
+        self.hover_dict["Beam"] = f"<b>Beam</b><br>{self.supported_section.designation if flag else ''}"
 
-        # In the web 3D viewer, bolts are fused into the Angle STL mesh.
-        self.hover_dict["Angle"] = (
-            f"<b>Angle</b>: ISA {self.seated_angle.designation if flag else ''}"
-            f"<br><b>Bolt</b> Grade: {self.bolt.bolt_grade_provided if flag else ''}, "
-            f"Dia: {int(self.bolt.bolt_diameter_provided) if flag else ''} mm, "
-            f"Nos: {self.bolt.bolts_required if flag else ''}"
-        )
-        # Keep separate key for future per-part meshes
-        self.hover_dict["Bolt"] = (
-            f"<b>Bolt</b><br>Grade: {self.bolt.bolt_grade_provided if flag else ''}"
-            f"<br>Diameter: {int(self.bolt.bolt_diameter_provided) if flag else ''} mm"
-            f"<br>No. of Bolts: {self.bolt.bolts_required if flag else ''}"
-        )
+        try:
+            # In the web 3D viewer, bolts are fused into the Angle STL mesh.
+            self.hover_dict["Seated Angle"] = (
+                f"<b>Seated Angle</b><br>ISA {self.seated_angle.designation if flag else ''}"
+                f"<br>Bolt Grade: {self.bolt.bolt_grade_provided if flag else ''}, "
+                f"Dia: {int(self.bolt.bolt_diameter_provided) if flag else ''} mm, "
+                f"Nos: {self.bolt.bolts_required if flag else ''}"
+            )
+            # Keep separate key for future per-part meshes
+            self.hover_dict["Bolt"] = (
+                f"<b>Bolt</b><br>Grade: {self.bolt.bolt_grade_provided if flag else ''}"
+                f"<br>Diameter: {int(self.bolt.bolt_diameter_provided) if flag else ''} mm"
+                f"<br>No. of Bolts: {self.bolt.bolts_required if flag else ''}"
+            )
+        except Exception:
+            pass
         
         return out_list
 

--- a/osdag_core/design_type/connection/seated_angle_connection.py
+++ b/osdag_core/design_type/connection/seated_angle_connection.py
@@ -531,9 +531,22 @@ class SeatedAngleConnection(ShearConnection):
         """     Top Angle Properties: End     """
         """"""""""""""""""""""""""""""""""""""""""""""""""""""
         # Populate hover dict
-        self.hover_dict["Bolt"] = f"<b>Bolt</b><br>Grade: {self.bolt.bolt_grade_provided if flag else ''}<br>Diameter: {int(self.bolt.bolt_diameter_provided) if flag else ''} mm<br>No. of Bolts: {self.bolt.bolts_required if flag else ''}"
-        
-        self.hover_dict["Angle"]= f"Angle: ISA {self.seated_angle.designation if flag else ''}"
+        self.hover_dict["Column"] = f"Column: {self.supporting_section.designation if flag else ''}"
+        self.hover_dict["Beam"] = f"Beam: {self.supported_section.designation if flag else ''}"
+
+        # In the web 3D viewer, bolts are fused into the Angle STL mesh.
+        self.hover_dict["Angle"] = (
+            f"<b>Angle</b>: ISA {self.seated_angle.designation if flag else ''}"
+            f"<br><b>Bolt</b> Grade: {self.bolt.bolt_grade_provided if flag else ''}, "
+            f"Dia: {int(self.bolt.bolt_diameter_provided) if flag else ''} mm, "
+            f"Nos: {self.bolt.bolts_required if flag else ''}"
+        )
+        # Keep separate key for future per-part meshes
+        self.hover_dict["Bolt"] = (
+            f"<b>Bolt</b><br>Grade: {self.bolt.bolt_grade_provided if flag else ''}"
+            f"<br>Diameter: {int(self.bolt.bolt_diameter_provided) if flag else ''} mm"
+            f"<br>No. of Bolts: {self.bolt.bolts_required if flag else ''}"
+        )
         
         return out_list
 

--- a/osdag_core/design_type/flexural_member/flexure.py
+++ b/osdag_core/design_type/flexural_member/flexure.py
@@ -629,6 +629,7 @@ class Flexure(Member):
 
         # Populate hover dict
         self.hover_dict["Flexure Member"] = (
+            f"<b>Flexure Member</b><br>"
             f"{self.result_designation if flag else ''}"
         )
 

--- a/osdag_core/design_type/flexural_member/flexure_cantilever.py
+++ b/osdag_core/design_type/flexural_member/flexure_cantilever.py
@@ -603,6 +603,7 @@ class Flexure_Cantilever(Member):
         # Populate hover dict
 
         self.hover_dict["Flexure Member"] = (
+            f"<b>Flexure Member</b><br>"
             f"{self.result_designation if flag else ''}"
         )
 

--- a/osdag_core/design_type/flexural_member/flexure_purlin.py
+++ b/osdag_core/design_type/flexural_member/flexure_purlin.py
@@ -694,6 +694,7 @@ class Flexure_Purlin(Member):
         t2 = ()
 
         self.hover_dict["Flexural Members"] = (
+            f"<b>Flexural Members</b><br>"
             f"{self.result_designation if flag else ''}"
         )
 

--- a/osdag_core/design_type/tension_member/tension_bolted.py
+++ b/osdag_core/design_type/tension_member/tension_bolted.py
@@ -732,9 +732,9 @@ class Tension_bolted(Member):
         # Populate Hover Dict
         self.hover_dict["Bolt"] = f"<b>Bolt</b><br>Grade: {self.bolt.bolt_grade_provided if flag else ''}<br>Diameter: {int(self.bolt.bolt_diameter_provided) if flag else ''} mm<br>No. of Bolts: {int(self.plate.bolts_one_line)*int(self.plate.bolt_line) if flag else ''}"
         
-        self.hover_dict["Plate"]= f"Plate: {float(self.plate.length) if flag else ''} mm x {float(self.plate.height) if flag else ''} mm x {self.plate.thickness_provided if flag else ''} mm"
+        self.hover_dict["Plate"] = f"<b>Plate</b><br>{float(self.plate.length) if flag else ''} mm x {float(self.plate.height) if flag else ''} mm x {self.plate.thickness_provided if flag else ''} mm"
         
-        self.hover_dict["Member"] = f"Member: {self.section_size_1.designation if flag else ''}"
+        self.hover_dict["Member"] = f"<b>Member</b>: {self.section_size_1.designation if flag else ''}"
 
         return out_list
 

--- a/osdag_core/design_type/tension_member/tension_welded.py
+++ b/osdag_core/design_type/tension_member/tension_welded.py
@@ -623,12 +623,13 @@ class Tension_welded(Member):
         )
 
         self.hover_dict["Plate"] = (
-            f"Plate: {float(self.plate.length) if flag else ''} mm x "
+            f"<b>Plate</b><br>"
+            f"{float(self.plate.length) if flag else ''} mm x "
             f"{float(self.plate.height) if flag else ''} mm x "
             f"{self.plate.thickness_provided if flag else ''} mm"
         )
 
-        self.hover_dict["Member"] = f"Member: {self.section_size_1.designation if flag else ''}"
+        self.hover_dict["Member"] = f"<b>Member</b>: {self.section_size_1.designation if flag else ''}"
 
         return out_list
 


### PR DESCRIPTION
- Standardized the CAD hover tooltips across all modules to use consistent HTML bolding for member labels (e.g., <b>Member</b>: Name).
- Added missing "Cover Plate" tooltip payload mappings for both Beam-to-Beam and Column-to-Column Splice connections (Bolted & Welded). 
- Fixed the colorPickerRef initialization bug in EngineeringModule that was crashing the UI upon load.
- Replaced the h-full container layout with flex-1 overflow-hidden so the bottom action buttons on the Input/Output sidebars no longer overflow off-screen.