### PR TITLE
Fix browser back button trapping and File > Quit menu redirection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,7 @@ backend/file_storage/cad_models/*.aux
 
 backend/firebase-service-account.json
 file_storage
+
+# Ignore local database folder
+pgdata/
+

--- a/frontend/src/modules/shared/components/EngineeringModule.jsx
+++ b/frontend/src/modules/shared/components/EngineeringModule.jsx
@@ -168,6 +168,7 @@ export const EngineeringModule = ({
     handleSubmit,
     handleReset,
     handleHomeClick,
+    handleQuitClick,
     performReset,
 
     // Report
@@ -867,6 +868,10 @@ export const EngineeringModule = ({
     }
     if (name === "Reset") {
       return handleResetEnhanced();
+    }
+    if (name === "Quit") {
+      handleQuitClick();
+      return;
     }
 
     // Reset/Downloads are handled elsewhere (existing handlers or upcoming reset work).

--- a/frontend/src/modules/shared/hooks/useEngineeringModule.js
+++ b/frontend/src/modules/shared/hooks/useEngineeringModule.js
@@ -206,7 +206,7 @@ export const useEngineeringModule = (moduleConfig) => {
     setConfirmationType,
     confirmNavigation,
     performNavigation,
-  } = useNavigationGuard(hasUnsavedWork, moduleConfig.routePath);
+  } = useNavigationGuard(hasUnsavedWork(), moduleConfig.routePath);
 
   // Design report
   const report = useDesignReport(
@@ -259,6 +259,14 @@ export const useEngineeringModule = (moduleConfig) => {
       confirmNavigation("navigation", "home");
     } else {
       navigate("/home");
+    }
+  };
+
+  const handleQuitClick = () => {
+    if (hasUnsavedWork()) {
+      confirmNavigation("navigation", "back");
+    } else {
+      navigate(-1);
     }
   };
 
@@ -392,6 +400,7 @@ export const useEngineeringModule = (moduleConfig) => {
     handleSubmit,
     handleReset,
     handleHomeClick,
+    handleQuitClick,
     performReset,
     saveOutput,
 

--- a/frontend/src/modules/shared/hooks/useNavigationGuard.js
+++ b/frontend/src/modules/shared/hooks/useNavigationGuard.js
@@ -16,10 +16,12 @@ export const useNavigationGuard = (hasUnsavedWork, routePath) => {
   const [allowNavigation, setAllowNavigation] = useState(false);
   const [navigationSource, setNavigationSource] = useState(null); // 'home' | 'back'
 
+  const hasUnsaved = typeof hasUnsavedWork === "function" ? hasUnsavedWork() : !!hasUnsavedWork;
+
   // Browser Guard (Refresh / Close Tab) and Back Button Guard
   useEffect(() => {
     const handleBeforeUnload = (event) => {
-      if (hasUnsavedWork) {
+      if (hasUnsaved) {
         const message = "You have unsaved design progress. Are you sure you want to leave?";
         event.preventDefault();
         event.returnValue = message;
@@ -28,7 +30,7 @@ export const useNavigationGuard = (hasUnsavedWork, routePath) => {
     };
 
     const handlePopState = () => {
-      if (hasUnsavedWork && !allowNavigation) {
+      if (hasUnsaved && !allowNavigation) {
         try {
           // Preserve the full current path (including projectId) so we don't
           // lose the project context when trapping the back button.
@@ -51,11 +53,11 @@ export const useNavigationGuard = (hasUnsavedWork, routePath) => {
       window.removeEventListener("beforeunload", handleBeforeUnload);
       window.removeEventListener("popstate", handlePopState);
     };
-  }, [allowNavigation, hasUnsavedWork, routePath]);
+  }, [allowNavigation, hasUnsaved, routePath]);
 
   // Ensure there's a history entry to trap back navigation when work is unsaved
   useEffect(() => {
-    if (!hasUnsavedWork) return;
+    if (!hasUnsaved) return;
     try {
       const path = window.location.pathname;
       if (path && window.location.origin) {
@@ -65,7 +67,7 @@ export const useNavigationGuard = (hasUnsavedWork, routePath) => {
       // pushState can throw "The operation is insecure" (e.g. post-login, iframe, or restricted context)
       if (e?.name !== "SecurityError") throw e;
     }
-  }, [hasUnsavedWork]);
+  }, [hasUnsaved]);
 
   const confirmNavigation = (type, source) => {
     setConfirmationType(type);


### PR DESCRIPTION
### Summary
This PR resolves two navigation issues in the connection module pages:
1. The browser's back button getting trapped/blocked.
2. The `File > Quit` menu action not navigating back in history.

---

### Key Changes

#### 1. Fixed Back Button Trap
- **Files**: `frontend/src/modules/shared/hooks/useNavigationGuard.js` and `frontend/src/modules/shared/hooks/useEngineeringModule.js`
- **Issue**: `hasUnsavedWork` was defined as a function but was passed directly as a function reference to `useNavigationGuard`. This caused the guard to always evaluate it as a truthy boolean and trigger database history state pushes (`window.history.pushState`) on every single component render, bloating the browser history stack and trapping the user on the page.
- **Fix**: Updated `useNavigationGuard` to dynamically evaluate `hasUnsavedWork` as a function or boolean, and updated `useEngineeringModule` to pass `hasUnsavedWork()` (the evaluated boolean value) directly. This stops the helper from running on every component render and only pushes history states when work actually becomes unsaved.

#### 2. Implemented History-Based Quit Action
- **Files**: `frontend/src/modules/shared/components/EngineeringModule.jsx` and `frontend/src/modules/shared/hooks/useEngineeringModule.js`
- **Issue**: Clicking `File > Quit` was ignored in the navbar dropdown click handler.
- **Fix**: Created a `handleQuitClick` action that performs history-based back navigation (`navigate(-1)`) rather than hardcoding it to `/home`. We mapped `"Quit"` in the navbar handler to call `handleQuitClick()`, which safely prompts the user with the "Unsaved Progress" modal if they have unsaved work, or goes back to the page they came from (e.g. `/connection`) if they have no unsaved work.

#### 3. Updated Gitignore
- **Files**: `.gitignore`
- **Fix**: Added `pgdata/` to the ignore list to ensure local PostgreSQL databases do not get checked in or pollute the git status.

---

### Testing & Verification
- Checked Guest Login flow. 
- Verified that pressing the browser back button immediately after opening a module successfully returns the user to the previous page (e.g. `/connection` or `/home`) without any confirmation modals.
- Verified that running a design (creating unsaved work) and then pressing back or selecting `File > Quit` correctly triggers the "Unsaved Progress" modal. Confirming it successfully discards work and routes the user back.
