### PR TITLE
fix: DesignReportModal crash and Butt Joint Bolted STEP/IGS export

### DIFF
--- a/backend/apps/modules/simple_connection/submodules/butt_joint_bolted/adapter.py
+++ b/backend/apps/modules/simple_connection/submodules/butt_joint_bolted/adapter.py
@@ -299,6 +299,22 @@ def create_cad_model(input_values: Dict[str, Any], section: str, session: str, e
     except Exception as stle:
         print(f"[ButtJointBolted CAD] Warning: Failed to save STL for {section}: {stle}")
 
+    # Optional on-demand STEP/IGES exports (only when frontend requests them)
+    export_formats_lc = {f.lower() for f in export_formats} if export_formats else set()
+    if export_formats_lc:
+        try:
+            from apps.core.utils.cad_export import export_step, export_iges
+            if "step" in export_formats_lc:
+                step_rel = file_path.replace(".brep", ".step")
+                export_step(model, os.path.join(os.getcwd(), step_rel))
+                print(f"[ButtJointBolted CAD] STEP file saved: {step_rel}")
+            if "iges" in export_formats_lc:
+                iges_rel = file_path.replace(".brep", ".iges")
+                export_iges(model, os.path.join(os.getcwd(), iges_rel))
+                print(f"[ButtJointBolted CAD] IGES file saved: {iges_rel}")
+        except Exception as e:
+            print(f"[ButtJointBolted CAD] Warning: Optional STEP/IGES export failed: {e}")
+
     print(f"[ButtJointBolted CAD] CAD generation completed successfully. Returning path: {file_path}")
     return file_path
 

--- a/frontend/src/modules/shared/components/DesignReportModal.jsx
+++ b/frontend/src/modules/shared/components/DesignReportModal.jsx
@@ -137,13 +137,20 @@ Group/TeamName: ${designReportInputs.groupTeamName}`;
         }
       }
       // Transform input values using the same logic as design calculation
-      const transformedInputValues = moduleConfig?.buildSubmissionParams ?
-        moduleConfig.buildSubmissionParams(inputValues, allSelected, lists || {
-          boltDiameterList,
-          propertyClassList,
-          thicknessList,
-          angleList,
-        }, extraState) : inputValues;
+      let transformedInputValues = inputValues;
+      if (moduleConfig?.buildSubmissionParams) {
+        try {
+          transformedInputValues = moduleConfig.buildSubmissionParams(inputValues, allSelected, lists || {
+            boltDiameterList,
+            propertyClassList,
+            thicknessList,
+            angleList,
+          }, extraState);
+        } catch (transformErr) {
+          console.warn("[DesignReportModal] buildSubmissionParams failed, using raw inputs:", transformErr.message);
+          transformedInputValues = inputValues;
+        }
+      }
 
       // Optionally capture CAD views for report images (frontend-driven).
       // Force Model view so report shows full assembly, not the current per-part view.


### PR DESCRIPTION
### Fixes

- **DesignReportModal crash** — Wrap `buildSubmissionParams` in try-catch to prevent crash when saved project inputs are incomplete (affects Generate Report from Recent Projects and Search)
- **Butt Joint Bolted STEP/IGS export** - Add STEP and IGS export support to the CAD adapter (File → Save 3D Model → Export STEP/IGS now works)
